### PR TITLE
Fixed bug causing floats to not properly convert from string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Editor settings
+.idea/
+.vscode/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/param.go
+++ b/param.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-chi/chi"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 // ErrInvalidParam is an error for not presented or invalid parameter
@@ -296,6 +297,11 @@ func QueryFloat32Array(r *http.Request, key string) ([]float32, error) {
 	}
 	out := make([]float32, len(values))
 	for index, value := range values {
+		// replace + stripped out during url parse stage
+		if strings.Contains(value, " ") {
+			value = strings.Replace(value, " ", "+", 1)
+		}
+
 		v, err := strconv.ParseFloat(value, 32)
 		if err != nil {
 			return nil, err
@@ -313,6 +319,11 @@ func QueryFloat64Array(r *http.Request, key string) ([]float64, error) {
 	}
 	out := make([]float64, len(values))
 	for index, value := range values {
+		// replace + stripped out during url parse stage
+		if strings.Contains(value, " ") {
+			value = strings.Replace(value, " ", "+", 1)
+		}
+
 		v, err := strconv.ParseFloat(value, 64)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
I found a small bug which would cause `QueryFloat32Array` and `QueryFloat64Array` to return an error. It seems that during the url parsing phase the `+` symbol is stripped out so `3.14e+2` becomes `3.14e 2` which causes ParseFloat to return an error for an improperly formatted float value.


